### PR TITLE
GA-11 Get bit array size data

### DIFF
--- a/src/data_persistence/FilePersistence.cpp
+++ b/src/data_persistence/FilePersistence.cpp
@@ -97,7 +97,7 @@ void FilePersistence::appendBlacklistedUrl(const std::string &url) {
 
 /**
  * Save the config ints, given by the user's input.
- * @param vector first int is bit array size (first int in the input), the rest are how many times to run hash function
+ * @param vector int array of how many times to run hash functions
  */
 std::vector<int> FilePersistence::loadConfigInts() {
     std::ifstream file(configIntsPath.c_str());
@@ -109,6 +109,9 @@ std::vector<int> FilePersistence::loadConfigInts() {
     // Read from the file and convert to the correct variable type (from a string)
     std::vector<int> loadedConfigInts;
     std::string line;
+    // Skip the first line (the bit array size)
+    std::getline(file, line);
+    // Get the ints
     while (std::getline(file, line)) {
         loadedConfigInts.push_back(std::stoi(line));
     }
@@ -149,7 +152,8 @@ int FilePersistence::getBitSizeConfig() {
     }
     // Get the first int from the file
     std::string line;
+    std::getline(file, line);
     int result = std::stoi(line);
     file.close();
-    return result
+    return result;
 }

--- a/src/data_persistence/FilePersistence.cpp
+++ b/src/data_persistence/FilePersistence.cpp
@@ -135,3 +135,21 @@ void FilePersistence::appendConfigInts(const std::vector<int>& configInts) {
     }
     file.close();
 }
+
+/**
+* Get from the config the size of the bit array.
+* @return an int representing the bit array size
+*/
+int FilePersistence::getBitSizeConfig() {
+    std::ifstream file(configIntsPath.c_str());
+    // If the file doesn't exist, create it and return an empty file.
+    if (!file.is_open()) {
+        std::ofstream createFile(configIntsPath.c_str());
+        return {};
+    }
+    // Get the first int from the file
+    std::string line;
+    int result = std::stoi(line);
+    file.close();
+    return result
+}

--- a/src/data_persistence/FilePersistence.h
+++ b/src/data_persistence/FilePersistence.h
@@ -31,6 +31,7 @@ public:
     // Config related function
     std::vector<int> loadConfigInts();
     void appendConfigInts(const std::vector<int>& configInts);
+    int getBitSizeConfig();
 };
 
 #endif

--- a/src/data_persistence/IDataPersistence.h
+++ b/src/data_persistence/IDataPersistence.h
@@ -50,5 +50,11 @@ public:
      * @return A vector where the first int is bit array size (first int in the input), the rest are how many times to run hash function
      */
     virtual std::vector<int> loadConfigInts() = 0;
+
+    /**
+     * Get from the config the size of the bit array.
+     * @return an int representing the bit array size
+     */
+    virtual int getBitSizeConfig() = 0;
 };
 #endif

--- a/tests/data_persistence_tests/FilePersistenceTests.cpp
+++ b/tests/data_persistence_tests/FilePersistenceTests.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <fstream>
 #include "data_persistence/FilePersistence.h"
+#include <iostream> // TODO: remove
 
 // Default paths for the .txt files.
 const std::string testBitsPath = "data/bloom_bits.txt";
@@ -208,7 +209,10 @@ TEST(appendConfigInts, AppendingConfigInts)
     std::vector<int> originalInts = {8, 1, 2, 4, 5};
     fp->appendConfigInts(originalInts);
     // Load the file
-    std::vector<int> loaded = fp->loadConfigInts();
+    std::vector<int> loaded = {};
+    loaded.push_back(fp->getBitSizeConfig());
+    std::vector<int> ints = fp->loadConfigInts();
+    loaded.insert(loaded.end(), ints.begin(), ints.end());
     // We expect the file to include all integers
     EXPECT_EQ(originalInts, loaded);
     deleteFiles();


### PR DESCRIPTION
Added the option to get just the bit array size.
using the get config ints will now only get the ints without it, requiring calling both if wanting to get both of them.